### PR TITLE
Use gluster from CentOS Extras

### DIFF
--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: install the epel rpm
   yum: name=http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
-- name: Install gluster repo
-  get_url: url=http://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL.repo/glusterfs-epel.repo dest=/etc/yum.repos.d/glusterfs-epel.repo
+- name: install gluster repo
+  yum: name=centos-release-gluster
 - name: install gluster server
   yum: name=glusterfs-server
 - name: start and enable glusterd


### PR DESCRIPTION
As per: https://download.gluster.org/pub/gluster/glusterfs/LATEST/EPEL/

Use the CentOS Storage SIG method for installing OSS Gluster
